### PR TITLE
ARMetalArgumentBuffersのサンプルの修正

### DIFF
--- a/chapter_13/06_ARMetalArgumentBuffers/ARMetalArgumentBuffers/MetalRenderView.swift
+++ b/chapter_13/06_ARMetalArgumentBuffers/ARMetalArgumentBuffers/MetalRenderView.swift
@@ -74,6 +74,7 @@ class MetalRenderView: MTKView, MTKViewDelegate {
         renderDescriptor = descriptor
 
         let samplerDescriptor = MTLSamplerDescriptor()
+        samplerDescriptor.supportArgumentBuffers = true
         sampler = device.makeSamplerState(descriptor: samplerDescriptor)!
         
         guard let fragmentFunction = renderDescriptor?.fragmentFunction else {return}


### PR DESCRIPTION
iOS11.2のiPhoneでARMetalArgumentBuffersのサンプルを起動すると動作が止まってしまうことがありましたので修正しました。

## 環境
Xcode9.2
iOS11.2
iPhone X、iPhone6S+の２機種で確認

## 問題の詳細

上記の環境で、XcodeでRunして起動すると以下のようなメッセージがログに表示され、そこで動作が止まってしまいました。
```
failed assertion `Sampler state did not have supportArgumentBuffers flag set on creation, but is used with argument buffers'
```

なお、同じ環境でもXcodeからのRunではなくインストールされたアプリを直接起動した場合には（おそらく）正常に動作しました。また、iOS11.1の実機でXcode9.2からRunした場合も特に止まることなく動作しました。

## 修正について
ログに出力されたメッセージの通りですが、リファレンスにもArgument BufferでMTLSamplerStateをエンコードする場合にはsupportArgumentBuffersをtrueにするよう書かれていましたので、その通りに修正しました。